### PR TITLE
Fix FPM version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:bullseye
 
+ARG FPM_VERSION=1.14.0
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       binutils \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,3 +18,5 @@ RUN apt-get update && \
     apt-get remove -y --purge ruby-dev && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["fpm"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,6 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
+WORKDIR "/app"
+
 ENTRYPOINT ["fpm"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
       ruby-dev \
       wget \
       make && \
-    gem install --no-document fpm && \
+    gem install --no-document fpm:${FPM_VERSION} && \
     apt-get remove -y --purge ruby-dev && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM debian:bullseye
-MAINTAINER adfinis.com <info@adfinis.com>
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This PR:

- Fixes the FPM version by gem to a version
- Adds a "workdir" statement
- Removes the deprecated "maintainer" statement
- Sets FPM as entrypoint